### PR TITLE
:sparkles: feature (Anc Second Screening): Implemented multi-child su…

### DIFF
--- a/flourish_form_validations/form_validators/caregiver_child_consent_form_validator.py
+++ b/flourish_form_validations/form_validators/caregiver_child_consent_form_validator.py
@@ -1,10 +1,11 @@
 import datetime
 import re
 
+import pytz
 from django.apps import apps as django_apps
 from django.core.exceptions import ValidationError
 from edc_base.utils import age
-from edc_constants.choices import FEMALE, MALE, YES, NO, NOT_APPLICABLE
+from edc_constants.choices import FEMALE, MALE, NO, NOT_APPLICABLE, YES
 from edc_form_validators import FormValidator
 from edc_form_validators.base_form_validator import NOT_APPLICABLE_ERROR
 
@@ -165,8 +166,7 @@ class CaregiverChildConsentFormValidator(FormValidator):
                     raise ValidationError(msg)
                 elif gender == MALE and cleaned_data.get('identity')[4] != '1':
                     msg = {'identity':
-                               'Participant is Male. Please correct identity '
-                               'number.'}
+                               'Participant is Male. Please correct identity number.'}
                     self._errors.update(msg)
                     raise ValidationError(msg)
 
@@ -183,20 +183,21 @@ class CaregiverChildConsentFormValidator(FormValidator):
         child_dob = cleaned_data.get('child_dob')
         consent_date = cleaned_data.get('consent_datetime')
 
+        # consent date should be used instead of the time right now
         if child_dob and consent_date:
-            child_dob = datetime.datetime.strptime(child_dob, "%Y-%m-%d").date()
-            # consent date should be used instead of the time right now
-            child_age = age(child_dob, consent_date).years
+            child_dob = datetime.datetime.strptime(child_dob, "%Y-%m-%d")
+            child_age = 0
+            if child_dob.date() < consent_date.date():
+                child_age = age(child_dob, consent_date).years
+
             if child_age < 16 and cleaned_data.get(
                     'child_knows_status') in [YES, NO]:
-                msg = {'child_knows_status':
-                           'Child is less than 16 years'}
+                msg = {'child_knows_status': 'Child is less than 16 years'}
                 self._errors.update(msg)
                 raise ValidationError(msg)
             elif child_age >= 16 and cleaned_data.get(
                     'child_knows_status') == NOT_APPLICABLE:
-                msg = {'child_knows_status':
-                           'This field is applicable'}
+                msg = {'child_knows_status': 'This field is applicable'}
                 self._errors.update(msg)
                 raise ValidationError(msg)
 
@@ -204,7 +205,8 @@ class CaregiverChildConsentFormValidator(FormValidator):
 
         child_dob = cleaned_data.get('child_dob')
         if child_dob:
-            date_jun_2025 = datetime.datetime.strptime("2025-01-30", "%Y-%m-%d").date()
+            date_jun_2025 = datetime.datetime.strptime("2025-01-30",
+                                                       "%Y-%m-%d").date()
             child_dob = datetime.datetime.strptime(child_dob, "%Y-%m-%d").date()
             child_age_at_2025 = age(child_dob, date_jun_2025).years
             if cleaned_data.get('gender') == 'F':

--- a/flourish_form_validations/form_validators/ultrasound_form_validator.py
+++ b/flourish_form_validations/form_validators/ultrasound_form_validator.py
@@ -1,6 +1,7 @@
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
 from edc_form_validators.form_validator import FormValidator
+
 from .crf_form_validator import FormValidatorMixin
 
 
@@ -45,16 +46,15 @@ class UltrasoundFormValidator(FormValidatorMixin, FormValidator):
                 cleaned_data.get('est_edd_ultrasound') >
                 cleaned_data.get('report_datetime').date() +
                 relativedelta(weeks=40)):
-            msg = {'est_edd_ultrasound':
-                   'Estimated edd by ultrasound cannot be'
-                   ' greater than 40 weeks from today'}
+            msg = {'est_edd_ultrasound': 'Estimated edd by ultrasound cannot be'
+                                         ' greater than 40 weeks from today'}
             self._errors.update(msg)
             raise ValidationError(msg)
 
         if cleaned_data.get('ga_by_ultrasound_wks') and (
                 cleaned_data.get('ga_by_ultrasound_wks') > 40):
             msg = {'ga_by_ultrasound_wks':
-                       ('GA by ultrasound cannot be greater than 40 weeks.')}
+                       'GA by ultrasound cannot be greater than 40 weeks.'}
 
             self._errors.update(msg)
             raise ValidationError(msg)
@@ -62,7 +62,7 @@ class UltrasoundFormValidator(FormValidatorMixin, FormValidator):
         if cleaned_data.get('ga_by_ultrasound_days') and (
                 cleaned_data.get('ga_by_ultrasound_days') > 7):
             msg = {'ga_by_ultrasound_days':
-                       ('GA by ultrasound days cannot be greater than 7 days.')}
+                       'GA by ultrasound days cannot be greater than 7 days.'}
 
             self._errors.update(msg)
             raise ValidationError(msg)
@@ -76,9 +76,8 @@ class UltrasoundFormValidator(FormValidatorMixin, FormValidator):
 
             est_conceive_date = (report_datetime.date() -
                                  relativedelta(weeks=ga_by_ultrasound))
-            if (est_edd_ultrasound):
-                weeks_between = (
-                                    (est_edd_ultrasound - est_conceive_date).days) / 7
+            if est_edd_ultrasound:
+                weeks_between = (est_edd_ultrasound - est_conceive_date).days / 7
 
                 if (weeks_between + 1) > ga_by_ultrasound:
 


### PR DESCRIPTION
…pport for ANC enrolledCaregiver

This commit addresses various changes to support the inclusion of multiple children to one caregiver in the Flourish Caregiver project. Child subject identifiers were added to antenatal screenings, ultra sounds, maternal deliveries and enrollment forms. The dashboard was updated to reflect the multi-child support. The addition of child subject identifiers aids in improving the tracking process, especially when handling multi-child scenarios. Lastly, print statements were removed for a cleaner codebase.