### PR TITLE
Add BriefDangerAssessmentForm Validator

### DIFF
--- a/flourish_form_validations/form_validators/__init__.py
+++ b/flourish_form_validations/form_validators/__init__.py
@@ -3,6 +3,7 @@ from .antenatal_enrollment_form_validation import \
 from .arvs_pre_pregnancy_form_validation import ArvsPrePregnancyFormValidator
 from .breastfeeding_questionnaire_form_validator import \
     BreastFeedingQuestionnaireFormValidator
+from .brief_danger_assessment_form_validator import BriefDangerAssessmentFormValidator
 from .caregiver_child_consent_form_validator import \
     CaregiverChildConsentFormValidator
 from .caregiver_clinical_measurements_form_validator import \

--- a/flourish_form_validations/form_validators/brief_danger_assessment_form_validator.py
+++ b/flourish_form_validations/form_validators/brief_danger_assessment_form_validator.py
@@ -1,0 +1,22 @@
+from edc_constants.constants import YES
+from edc_form_validators import FormValidator
+
+from flourish_form_validations.form_validators.crf_form_validator import \
+    FormValidatorMixin
+
+
+class BriefDangerAssessmentFormValidator(FormValidatorMixin, FormValidator):
+
+    def clean(self):
+        self.required_if(
+            YES,
+            field='child_been_physically_hurt',
+            field_required='last_time_child_hurt_datetime')
+
+        last_time_child_hurt_datetime = self.cleaned_data.get(
+            'last_time_child_hurt_datetime')
+
+        self.required_if_true(
+            last_time_child_hurt_datetime is not None,
+            field_required='last_time_child_hurt_estimated',
+        )


### PR DESCRIPTION
Added a new form validator, BriefDangerAssessmentFormValidator, to the Flourish form validations library. This validator checks for valid input criteria based on the fields 'child_been_physically_hurt' and 'last_time_child_hurt_datetime.' If the child has been physically hurt, the datetime of the last incident is required. Moreover, if the datetime is provided, an estimation of the time the child was hurt is also required. This enforcement ensures that the necessary details are captured where they are inbound to incidents of potential danger to the child.