### PR TITLE
refactor(Validations): Refactor TB form validators for efficiency


### DIFF
--- a/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
+++ b/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
@@ -20,27 +20,26 @@ class CaregiverTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
                          field='evaluated_for_tb',
                          field_required='clinic_visit_date')
 
-        self.validate_other_specify(
-            field='tb_tests',
-            other_specify_field='other_test',
+        self.m2m_other_specify(
+            m2m_field='tb_tests',
+            field_other='other_test',
         )
 
-        self.required_if('chest_xray',
-                         field='tb_tests',
-                         field_required='chest_xray_results')
+        field_responses = {
+            'chest_xray': 'chest_xray_results',
+            'sputum_sample': 'sputum_sample_results',
+            'urine_test': 'urine_test_results',
+            'skin_test': 'skin_test_results',
+            'blood_test': 'blood_test_results',
+        }
 
-        self.required_if('sputum_sample',
-                         field='tb_tests',
-                         field_required='sputum_sample_results')
+        for field, response in field_responses.items():
+            self.m2m_required_if(
+                response,
+                m2m_field='tb_tests',
+                field=field,
+            )
 
-        self.required_if('urine_test',
-                         field='tb_tests',
-                         field_required='urine_test_results')
-
-        self.required_if('skin_test',
-                         field='tb_tests',
-                         field_required='skin_test_results')
-
-        self.required_if('blood_test',
-                         field='tb_tests',
-                         field_required='blood_test_results')
+        self.required_if(YES,
+                         field='diagnosed_with_TB',
+                         field_required='started_on_TB_treatment')

--- a/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
+++ b/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ValidationError
 from edc_constants.constants import YES
 from edc_form_validators import FormValidator
 
@@ -39,18 +38,8 @@ class CaregiverTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
         }
 
         for response, field in field_responses.items():
-            self.required_if_m2m(
+            self.m2m_other_specify(
                 response,
                 m2m_field='tb_tests',
-                field=field,
+                field_other=field,
             )
-
-    def required_if_m2m(self, response, field=None, m2m_field=None):
-        m2m_field = self.cleaned_data.get(m2m_field)
-        selected = {obj.short_name: obj.name for obj in m2m_field if
-                    m2m_field is not None}
-        if response:
-            if response not in selected and not self.cleaned_data.get(field):
-                message = {field: 'This field is applicable'}
-                self._errors.update(message)
-                raise ValidationError(message)

--- a/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
+++ b/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
@@ -1,4 +1,4 @@
-from edc_constants.constants import YES
+from edc_constants.constants import OTHER, YES
 from edc_form_validators import FormValidator
 
 from flourish_child_validations.form_validators import ChildFormValidatorMixin
@@ -21,6 +21,7 @@ class CaregiverTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
                          field_required='clinic_visit_date')
 
         self.m2m_other_specify(
+            OTHER,
             m2m_field='tb_tests',
             field_other='other_test',
         )


### PR DESCRIPTION
'validate_other_specify' was updated to 'm2m_other_specify' in the TB form validators. Repetitive 'required_if' instances were also replaced with the implementation of a dictionary. This significantly improves code readability and efficiency.