### PR TITLE
Refactor required_if arguments in hits_screening_form_validator.py



### DIFF
--- a/flourish_form_validations/form_validators/hits_screening_form_validator.py
+++ b/flourish_form_validations/form_validators/hits_screening_form_validator.py
@@ -11,5 +11,5 @@ class HITSScreeningFormValidator(FormValidatorMixin, FormValidator):
         for field in fields:
             self.required_if(
                 YES,
-                field=field,
-                field_required='in_relationship')
+                field_required=field,
+                field='in_relationship')


### PR DESCRIPTION
Swapped the 'field' and 'field_required' arguments in the required_if method in the hits_screening_form_validator.py file. This ensures proper function of the 'in_relationship' field, improving the form's capabilities and validity.