### PR TITLE
7308

### DIFF
--- a/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
+++ b/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
@@ -1,14 +1,12 @@
-from edc_constants.constants import NO, OTHER, YES
+from edc_constants.constants import NO, NONE, OTHER, YES
 from edc_form_validators import FormValidator
 
-from flourish_caregiver.constants import NONE
 from .crf_form_validator import FormValidatorMixin
 
 
 class CaregiverTBScreeningFormValidator(FormValidatorMixin, FormValidator):
 
     def clean(self):
-        breakpoint()
         super().clean()
 
         required_fields = ['cough', 'fever', 'sweats', 'weight_loss']

--- a/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
+++ b/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
@@ -2,12 +2,13 @@ from edc_constants.constants import NO, OTHER, YES
 from edc_form_validators import FormValidator
 
 from flourish_caregiver.constants import NONE
-from flourish_child_validations.form_validators import ChildFormValidatorMixin
+from .crf_form_validator import FormValidatorMixin
 
 
-class CaregiverTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
+class CaregiverTBScreeningFormValidator(FormValidatorMixin, FormValidator):
 
     def clean(self):
+        breakpoint()
         super().clean()
 
         required_fields = ['cough', 'fever', 'sweats', 'weight_loss']


### PR DESCRIPTION
In 'caregiver_tb_screening_form_validator.py', the unused import `NONE` from `flourish_caregiver.constants` and the redundant `breakpoint()` were removed. This commit also optimized the import of `NONE` by importing it directly from `edc_constants.constants` rather than `flourish_caregiver.constants`, reducing code complexity.