### PR TITLE
(Feature): Add new form validation for TB screening



### DIFF
--- a/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
+++ b/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
@@ -16,6 +16,12 @@ class CaregiverTBScreeningFormValidator(FormValidatorMixin, FormValidator):
                              field=field,
                              field_required=f'{field}_duration')
 
+        self.required_if(
+            YES,
+            field='household_diagnosed_with_tb',
+            field_required='evaluated_for_tb'
+        )
+
         self.required_if(YES,
                          field='evaluated_for_tb',
                          field_required='clinic_visit_date')


### PR DESCRIPTION
A new form validation rule has been added to the `caregiver_tb_screening_form_validator.py` script. This rule mandates that if a household member is diagnosed with Tuberculosis (TB), it is mandatory to check if they have been evaluated for TB. This enhances the app's capability to efficiently manage and track TB screenings. Signed-off-by: nmunatsibw 