### PR TITLE
(delete): Remove redundant validation check in caregiver_tb_screening_form_validator


### DIFF
--- a/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
+++ b/flourish_form_validations/form_validators/caregiver_tb_screening_form_validator.py
@@ -16,12 +16,6 @@ class CaregiverTBScreeningFormValidator(FormValidatorMixin, FormValidator):
                              field=field,
                              field_required=f'{field}_duration')
 
-        self.required_if(
-            YES,
-            field='household_diagnosed_with_tb',
-            field_required='evaluated_for_tb'
-        )
-
         self.required_if(YES,
                          field='evaluated_for_tb',
                          field_required='clinic_visit_date')


### PR DESCRIPTION

The code for validating if 'evaluated_for_tb' is required when 'household_diagnosed_with_tb' is 'YES' has been deleted. This validation rule was redundant and not necessary in the context of the form validation requirements in caregiver_tb_screening_form_validator. Signed-off-by: nmunatsibw 